### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.3.0
+  - 2.4.2
+  - 2.3.5
   - 2.2
-  - 2.0
-  - 1.9.3
+  - 2.1
 
 before_script:
   - wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz

--- a/fluent-plugin-geoip-filter.gemspec
+++ b/fluent-plugin-geoip-filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", ">= 0.12"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_runtime_dependency "geoip", ">= 1.5.0"
   spec.add_runtime_dependency "lru_redux", ">= 1.0.0"
   spec.add_development_dependency "bundler"

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -1,9 +1,10 @@
 require 'geoip'
 require 'lru_redux'
+require 'fluent/plugin/filter'
 
-module Fluent
+module Fluent::Plugin
   class GeoipFilter < Filter
-    Plugin.register_filter('geoip', self)
+    Fluent::Plugin.register_filter('geoip', self)
 
     def initialize
       @geoip_cache = LruRedux::Cache.new(8192)
@@ -65,5 +66,5 @@ module Fluent
       ret
     end
 
-  end if defined?(Filter) # Support only >= v0.12
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,8 +21,10 @@ unless ENV.has_key?('VERBOSE')
   }
   $log = nulllogger
 end
-
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_geoip'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
Using v0.14 API permits to handle nanosecond precision time in event.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.